### PR TITLE
Fix a bug in reading optional strings

### DIFF
--- a/examples/people/main.go
+++ b/examples/people/main.go
@@ -3,8 +3,8 @@ package main
 //go:generate parquetgen -input main.go -type Person -package main
 
 import (
+	"encoding/json"
 	"flag"
-	"fmt"
 	"log"
 	"os"
 )
@@ -30,7 +30,7 @@ func write() {
 
 	defer f.Close()
 
-	w, err := NewParquetWriter(f)
+	w, err := NewParquetWriter(f, MaxPageSize(100))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -70,10 +70,11 @@ func read() {
 		log.Fatal(err)
 	}
 
+	enc := json.NewEncoder(os.Stdout)
 	for r.Next() {
 		var p Person
 		r.Scan(&p)
-		fmt.Printf("%+v\n", p)
+		enc.Encode(p)
 	}
 }
 
@@ -88,7 +89,7 @@ type Person struct {
 	Being
 	Happiness   int64    `parquet:"happiness"`
 	Sadness     *int64   `parquet:"sadness"`
-	Code        string   `parquet:"code"`
+	Code        *string  `parquet:"code"`
 	Funkiness   float32  `parquet:"funkiness"`
 	Lameness    *float32 `parquet:"lameness"`
 	Keen        *bool    `parquet:"keen"`

--- a/examples/people/people.go
+++ b/examples/people/people.go
@@ -12,12 +12,17 @@ func init() {
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
-func randString(n int) string {
+func randString(n int) *string {
+	if rand.Intn(2) == 0 {
+		return nil
+	}
+
 	b := make([]rune, n)
 	for i := range b {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
-	return string(b)
+	s := string(b)
+	return &s
 }
 
 func newPerson(i int) Person {
@@ -34,7 +39,7 @@ func newPerson(i int) Person {
 	}
 
 	var lameness *float32
-	if i%4 == 0 {
+	if rand.Intn(2) == 0 {
 		l := rand.Float32()
 		lameness = &l
 	}

--- a/parquet.go
+++ b/parquet.go
@@ -58,8 +58,8 @@ func (m *Metadata) StartRowGroup(fields ...Field) {
 	})
 }
 
-func (m *Metadata) RowGroups() int {
-	return len(m.metadata.RowGroups)
+func (m *Metadata) RowGroups() []*sch.RowGroup {
+	return m.metadata.RowGroups
 }
 
 // WritePageHeader indicates you are done writing this columns's chunk


### PR DESCRIPTION
Also, handle the case where the fields in the parquet file
are not in the same order as the field definitions
in the struct.