### PR TITLE
Read row groups as needed

### DIFF
--- a/examples/people/main.go
+++ b/examples/people/main.go
@@ -76,6 +76,10 @@ func read() {
 		r.Scan(&p)
 		enc.Encode(p)
 	}
+
+	if err := r.Error(); err != nil {
+		log.Fatal(err)
+	}
 }
 
 // Being is split out only to show how embedded structs


### PR DESCRIPTION
This avoids reading all the parquet data into memory at once