### PR TITLE
Import bug

### DIFF
--- a/cmd/parquetgen/dremel/testcases/doc/generated.go
+++ b/cmd/parquetgen/dremel/testcases/doc/generated.go
@@ -6,14 +6,15 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 
 	"github.com/parsyl/parquet"
 	sch "github.com/parsyl/parquet/schema"
 	"github.com/valyala/bytebufferpool"
-
-	"math"
 )
+
+var _ = math.MaxInt32 // to avoid unused import
 
 type compression int
 

--- a/cmd/parquetgen/dremel/testcases/person/generated.go
+++ b/cmd/parquetgen/dremel/testcases/person/generated.go
@@ -6,14 +6,15 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 
 	"github.com/parsyl/parquet"
 	sch "github.com/parsyl/parquet/schema"
 	"github.com/valyala/bytebufferpool"
-
-	"math"
 )
+
+var _ = math.MaxInt32 // to avoid unused import
 
 type compression int
 

--- a/cmd/parquetgen/dremel/testcases/repetition/generated.go
+++ b/cmd/parquetgen/dremel/testcases/repetition/generated.go
@@ -6,12 +6,15 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 
 	"github.com/parsyl/parquet"
 	sch "github.com/parsyl/parquet/schema"
 	"github.com/valyala/bytebufferpool"
 )
+
+var _ = math.MaxInt32 // to avoid unused import
 
 type compression int
 

--- a/cmd/parquetgen/gen/funcs.go
+++ b/cmd/parquetgen/gen/funcs.go
@@ -41,17 +41,6 @@ var (
 			}
 			return strings.Join(names, ", ")
 		},
-		"imports": func(fields []fields.Field) []string {
-			var out []string
-			var intFound bool
-			for _, f := range fields {
-				if !intFound && strings.Contains(f.Type, "int") {
-					intFound = true
-					out = append(out, `"math"`)
-				}
-			}
-			return out
-		},
 		"maxType": func(f fields.Field) string {
 			var out string
 			switch f.Type {

--- a/cmd/parquetgen/gen/template.go
+++ b/cmd/parquetgen/gen/template.go
@@ -11,14 +11,15 @@ import (
 	"io"
 	"strings"
 	"encoding/binary"
+	"math"
 
 	"github.com/valyala/bytebufferpool"
 	"github.com/parsyl/parquet"
 	sch "github.com/parsyl/parquet/schema"
-	{{.Import}}
-	{{range imports .Parent.Fields}}{{.}}
-	{{end}}
+	
 )
+
+var _ = math.MaxInt32 // to avoid unused import
 
 type compression int
 

--- a/parquet_generated_test.go
+++ b/parquet_generated_test.go
@@ -6,14 +6,15 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 
 	"github.com/parsyl/parquet"
 	sch "github.com/parsyl/parquet/schema"
 	"github.com/valyala/bytebufferpool"
-
-	"math"
 )
+
+var _ = math.MaxInt32 // to avoid unused import
 
 type compression int
 


### PR DESCRIPTION
PR #14 has introduced a bug.
after that PR, both `int` and `float` types are using the package `math`,
but the condition to import `math` was that `int` is present in the types

in case of a struct that contains a `float` but not an `int`, the generated file wont import `math` and the file wont compile

to simplify things, I just always import `math`, and make sure that it is used to avoid an unused import error