### PR TITLE
fix: optional schema fields are always set to 0

### DIFF
--- a/parquet.go
+++ b/parquet.go
@@ -72,11 +72,7 @@ func (s schema) schema() (int64, []*sch.SchemaElement) {
 		}
 
 		se := &sch.SchemaElement{
-			Name:       f.Path[len(f.Path)-1],
-			TypeLength: &z,
-			Scale:      &z,
-			Precision:  &z,
-			FieldID:    &z,
+			Name: f.Path[len(f.Path)-1],
 		}
 
 		f.Type(se)
@@ -310,13 +306,8 @@ func (r *RowGroup) updateColumnChunk(pth []string, dataLen, compressedLen, count
 func schemaElements(fields []Field) schema {
 	m := make(map[string]sch.SchemaElement)
 	for _, f := range fields {
-		var z int32
 		se := sch.SchemaElement{
-			Name:       f.Name,
-			TypeLength: &z,
-			Scale:      &z,
-			Precision:  &z,
-			FieldID:    &z,
+			Name: f.Name,
 		}
 
 		f.Type(&se)


### PR DESCRIPTION
`SchemaElement` int32 optional fields like `FieldId`, `Scale`, `Precision` etc. are always serialised with value 0. 
See for example the schema generated for the example in `_examples/people/`:
```
$> parquet-tools schema --format raw people.parquet
```
returns
```JSON
{
    "name": "Root",
    "num_children": 13,
    "children": [
        {
            "type": "INT32",
            "type_length": 0,
            "repetition_type": "REQUIRED",
            "name": "Id",
            "scale": 0,
            "precision": 0,
            "field_id": 0
        },
        {
            "type": "INT32",
            "type_length": 0,
            "repetition_type": "OPTIONAL",
            "name": "Age",
            "scale": 0,
            "precision": 0,
            "field_id": 0
        },
        {
            "type": "INT64",
            "type_length": 0,
            "repetition_type": "REQUIRED",
            "name": "Happiness",
            "scale": 0,
            "precision": 0,
            "field_id": 0
        },
        {
            "type": "INT64",
            "type_length": 0,
            "repetition_type": "OPTIONAL",
            "name": "Sadness",
            "scale": 0,
            "precision": 0,
            "field_id": 0
        },
        {
            "type": "BYTE_ARRAY",
            "type_length": 0,
            "repetition_type": "OPTIONAL",
            "name": "Code",
            "scale": 0,
            "precision": 0,
            "field_id": 0
        },
        {
            "type": "FLOAT",
            "type_length": 0,
            "repetition_type": "REQUIRED",
            "name": "Funkiness",
            "scale": 0,
            "precision": 0,
            "field_id": 0
        },
        {
            "type": "FLOAT",
            "type_length": 0,
            "repetition_type": "OPTIONAL",
            "name": "Lameness",
            "scale": 0,
            "precision": 0,
            "field_id": 0
        },
        {
            "type": "BOOLEAN",
            "type_length": 0,
            "repetition_type": "OPTIONAL",
            "name": "Keen",
            "scale": 0,
            "precision": 0,
            "field_id": 0
        },
        {
            "type": "INT32",
            "type_length": 0,
            "repetition_type": "REQUIRED",
            "name": "Birthday",
            "converted_type": "UINT_32",
            "scale": 0,
            "precision": 0,
            "field_id": 0
        },
        {
            "type": "INT64",
            "type_length": 0,
            "repetition_type": "OPTIONAL",
            "name": "Anniversary",
            "converted_type": "UINT_64",
            "scale": 0,
            "precision": 0,
            "field_id": 0
        },
        {
            "type": "INT32",
            "type_length": 0,
            "repetition_type": "OPTIONAL",
            "name": "Difficulty",
            "scale": 0,
            "precision": 0,
            "field_id": 0
        },
        {
            "repetition_type": "OPTIONAL",
            "name": "Hobby",
            "num_children": 2,
            "children": [
                {
                    "type": "BYTE_ARRAY",
                    "type_length": 0,
                    "repetition_type": "REQUIRED",
                    "name": "Name",
                    "scale": 0,
                    "precision": 0,
                    "field_id": 0
                },
                {
                    "type": "INT32",
                    "type_length": 0,
                    "repetition_type": "OPTIONAL",
                    "name": "Difficulty",
                    "scale": 0,
                    "precision": 0,
                    "field_id": 0
                }
            ]
        },
        {
            "repetition_type": "REPEATED",
            "name": "Friends",
            "num_children": 2,
            "children": [
                {
                    "type": "INT32",
                    "type_length": 0,
                    "repetition_type": "REQUIRED",
                    "name": "Id",
                    "scale": 0,
                    "precision": 0,
                    "field_id": 0
                },
                {
                    "type": "INT32",
                    "type_length": 0,
                    "repetition_type": "OPTIONAL",
                    "name": "Age",
                    "scale": 0,
                    "precision": 0,
                    "field_id": 0
                }
            ]
        }
    ]
}
```
This can have unintended consequences with any Parquet reader that explicitly uses the schema.
Additionally the fields are only serialised if they are not `nil`, see [here](https://github.com/parsyl/parquet/blob/6e611199a21380b95b984ccff47a359f36f337ab/schema/parquet.go#L3379C1-L3401C2).

With the proposed changes the schema for the example in `_examples/people/` is:
```JSON
{
    "name": "Root",
    "num_children": 13,
    "children": [
        {
            "type": "INT32",
            "repetition_type": "REQUIRED",
            "name": "Id"
        },
        {
            "type": "INT32",
            "repetition_type": "OPTIONAL",
            "name": "Age"
        },
        {
            "type": "INT64",
            "repetition_type": "REQUIRED",
            "name": "Happiness"
        },
        {
            "type": "INT64",
            "repetition_type": "OPTIONAL",
            "name": "Sadness"
        },
        {
            "type": "BYTE_ARRAY",
            "repetition_type": "OPTIONAL",
            "name": "Code"
        },
        {
            "type": "FLOAT",
            "repetition_type": "REQUIRED",
            "name": "Funkiness"
        },
        {
            "type": "FLOAT",
            "repetition_type": "OPTIONAL",
            "name": "Lameness"
        },
        {
            "type": "BOOLEAN",
            "repetition_type": "OPTIONAL",
            "name": "Keen"
        },
        {
            "type": "INT32",
            "repetition_type": "REQUIRED",
            "name": "Birthday",
            "converted_type": "UINT_32"
        },
        {
            "type": "INT64",
            "repetition_type": "OPTIONAL",
            "name": "Anniversary",
            "converted_type": "UINT_64"
        },
        {
            "type": "INT32",
            "repetition_type": "OPTIONAL",
            "name": "Difficulty"
        },
        {
            "repetition_type": "OPTIONAL",
            "name": "Hobby",
            "num_children": 2,
            "children": [
                {
                    "type": "BYTE_ARRAY",
                    "repetition_type": "REQUIRED",
                    "name": "Name"
                },
                {
                    "type": "INT32",
                    "repetition_type": "OPTIONAL",
                    "name": "Difficulty"
                }
            ]
        },
        {
            "repetition_type": "REPEATED",
            "name": "Friends",
            "num_children": 2,
            "children": [
                {
                    "type": "INT32",
                    "repetition_type": "REQUIRED",
                    "name": "Id"
                },
                {
                    "type": "INT32",
                    "repetition_type": "OPTIONAL",
                    "name": "Age"
                }
            ]
        }
    ]
}
```